### PR TITLE
Fix/Fix DoMe on linux

### DIFF
--- a/dome/autonomouscontroller.py
+++ b/dome/autonomouscontroller.py
@@ -220,7 +220,9 @@ class AutonomousController:
                         self.__DE.addAttribute(domain_entity, att_name, "str")
         try:
             self.__IC.update_app_web()
-        except BaseException:
+        except Exception as e:
+            
+            print("ERRO: ", str(e))
             # rollback the entity and attributes
             self.__DE.init_entities()
             raise Exception("Error updating the model")

--- a/dome/infrastructurecontroller.py
+++ b/dome/infrastructurecontroller.py
@@ -248,7 +248,9 @@ class InterfaceController:
                 strFileBuffer = strFileBuffer[:-3] + '"'
 
         # re-writing the model.py file
-        overwriting_file(self.__webapp_path + '\\models.py', strFileBuffer)      
+        modelFile = self.__checkPath(self.__webapp_path + '\\models.py')
+        
+        overwriting_file(modelFile, strFileBuffer)      
         self.migrateModel()
 
     def update_app_web(self, run_server=False):

--- a/dome/infrastructurecontroller.py
+++ b/dome/infrastructurecontroller.py
@@ -134,7 +134,6 @@ class InterfaceController:
                         file.write(
                             "import os, sys \nsys.path.append(os.path.join(BASE_DIR, '../'))"
                         )  # append missing data
-
             # overwrite the urls.py file
             urlPath = self.__checkPath(self.__settings_path + '\\urls.py')
             overwriting_file(urlPath, strFileContent)
@@ -202,8 +201,10 @@ class InterfaceController:
 
         strFileBuffer += '\nadmin.site.unregister(Group)'
         strFileBuffer += '\nadmin.site.unregister(User)\n'
+        
+        adminPath = self.__checkPath(self.__webapp_path + '\\admin.py')
 
-        overwriting_file(self.__webapp_path + '\\admin.py', strFileBuffer)
+        overwriting_file(adminPath, strFileBuffer)
                 
         # update models.py
         if DEBUG_MODE and PRINT_DEBUG_MSGS:
@@ -259,7 +260,7 @@ class InterfaceController:
     def __getEntities(self) -> list:
         return self.__AC.getEntities()
 
-    def migrateModel(self):
+    def     migrateModel(self):
         if DEBUG_MODE and PRINT_DEBUG_MSGS:
             print('migrating model...')
 

--- a/dome/infrastructurecontroller.py
+++ b/dome/infrastructurecontroller.py
@@ -75,6 +75,7 @@ class InterfaceController:
         print('creating django config dir...')
         self.__config_path = self.__checkPath(MANAGED_SYSTEM_NAME + SUFFIX_CONFIG)
         self.__settings_path = self.__checkPath(self.__config_path + '\\' + self.__config_path)
+        
         if not os.path.exists(self.__config_path):
             print('starting django project...')
             self.__runSyncCmd('Scripts\\django-admin.exe startproject ' + self.__config_path)  # synchronous
@@ -87,7 +88,10 @@ class InterfaceController:
             self.__runSyncCmd(
                 'Scripts\\python.exe  ' + self.__config_path + '\\manage.py startapp ' + self.__webapp_path)  # synchronous
             # extra setup in settings.py
-            for line in fileinput.FileInput(self.__settings_path + '\\settings.py', inplace=1):
+            
+            path = self.__checkPath(self.__settings_path + '\\settings.py')
+            
+            for line in fileinput.FileInput(path, inplace=1):
                 if "    'django.contrib.staticfiles'," in line:
                     line = line.replace(line, "    'livesync',\n" + line + "    '" + self.__webapp_path
                                         + '.apps.' + self.__webapp_path.replace('_', ' ').title().replace(' ', '')
@@ -121,8 +125,19 @@ class InterfaceController:
                              "\nadmin.site.index_title = \"" + MANAGED_SYSTEM_WEBAPP_TITLE + "\""
 
             print('updating urls.py file...')
+            
+            with open(self.__settings_path + "/settings.py", "r+") as file:
+                for line in file:
+                    if "import os, sys" in line:
+                        break
+                    else:  # not found, we are at the eof
+                        file.write(
+                            "import os, sys \nsys.path.append(os.path.join(BASE_DIR, '../'))"
+                        )  # append missing data
+
             # overwrite the urls.py file
-            overwriting_file(self.__settings_path + '\\urls.py', strFileContent)
+            urlPath = self.__checkPath(self.__settings_path + '\\urls.py')
+            overwriting_file(urlPath, strFileContent)
 
             self.migrateModel()
             # creating superuser


### PR DESCRIPTION
apenas forcei para que ao gerar o managedsys_config, no arquivo settings.py, ele adicionar ao final do arquivo uma chamada para o python considerar as pastas anteriores à do managedsys_config, resolvendo por fim o problema no linux.

em seguida atualizei algumas funções que antes não utilizavam a função de converter a string de diretorio de acordo com o sistema operacional.